### PR TITLE
- Add external field to skip signature decoration

### DIFF
--- a/SwiftTrace/SwiftArgs.swift
+++ b/SwiftTrace/SwiftArgs.swift
@@ -96,8 +96,8 @@ public func returner<Type>(value: Type, out: inout Any?) {
 extension SwiftTrace {
     
     /**
-     'true' skips any decoration steps when visiting Swift code
-     'false' decorates normally
+     'false' skips any decoration steps when visiting Swift code
+     'true' decorates normally
      */
     static public var swiftDecorateArgs = (onEntry: true, onExit: true)
 

--- a/SwiftTrace/SwiftArgs.swift
+++ b/SwiftTrace/SwiftArgs.swift
@@ -94,6 +94,12 @@ public func returner<Type>(value: Type, out: inout Any?) {
 }
 
 extension SwiftTrace {
+    
+    /**
+     'true' skips any decoration steps when visiting Swift code
+     'false' decorates normally
+     */
+    static public var swiftDecorateArgs = (onEntry: true, onExit: true)
 
     /**
      Enable auto decoration of unknown types
@@ -297,6 +303,8 @@ extension SwiftTrace {
          substitute argument values into signature on method entry
          */
         open override func entryDecorate(stack: inout EntryStack) -> String? {
+            guard SwiftTrace.swiftDecorateArgs.onEntry else { return signature }
+            
             let invocation = self.invocation()!
             return objcMethod != nil ?
                 objcDecorate(signature: nil, invocation: invocation) :
@@ -308,6 +316,8 @@ extension SwiftTrace {
          Determine return value on method exit
          */
         open override func exitDecorate(stack: inout ExitStack) -> String? {
+            guard SwiftTrace.swiftDecorateArgs.onExit else { return signature }
+            
             let invocation = self.invocation()!
             return objcMethod != nil ?
                 objcDecorate(signature: invocation.decorated ?? signature,


### PR DESCRIPTION
Hey! I've been using this as a simple but effective workaround for functions with particularly long or troublesome values. It's fairly blunt, as it directly returns an entry or exit signature if the flag is off, but so far, this has let me get to to high level function invocations, and cleared out string spew.

Happy to include any other suggested changes, offer a hand elsewhere in this vein, or simply to close it down if you feel there are better options. For example, I could see there being a much more robust registration of specific function signatures to skip.

Cheers!

